### PR TITLE
Auth

### DIFF
--- a/discoenv/Cargo.toml
+++ b/discoenv/Cargo.toml
@@ -29,6 +29,7 @@ async-nats = { version = "0.29.0", features = ["service"] }
 futures = "0.3.28"
 prost = "0.11.8"
 reqwest = { version = "0.11.16", features = ["json", "blocking", "rustls", "tokio-rustls", "rustls-tls"] }
+url = { version = "2.3.1", features = ["serde"] }
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/discoenv/Cargo.toml
+++ b/discoenv/Cargo.toml
@@ -11,7 +11,7 @@ axum = { version = "0.6.10", features = ["headers", "http2", "macros", "multipar
 axum-auth = { version = "0.4", default-features = false, features = ["auth-basic"] }
 axum-tracing-opentelemetry = { version = "0.10.0", features = ["jaeger", "tracing_subscriber_ext", "tracer", "otlp"] }
 clap = { version = "4.1.8", features = ["derive", "env"] }
-debuff = { git = "https://github.com/cyverse-de/p", rev="3fefb209bb05bfea5056f8ce42b550287afa1e5b" }
+debuff = { git = "https://github.com/cyverse-de/p", rev="621d538d8e569d3e9d73716c7487aed760db075a" }
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 pbjson-types = "0.5.1"
 serde = { version = "1.0.154", features = ["derive", "serde_derive"] }

--- a/discoenv/Cargo.toml
+++ b/discoenv/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.11.16", features = ["json", "blocking", "rustls", "toki
 url = { version = "2.3.1", features = ["serde"] }
 cached = { version = "0.43.0", features = ["serde", "serde_json"] }
 chrono = { version = "0.4.24", features = ["serde"] }
+exitcode = "1.1.2"
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/discoenv/Cargo.toml
+++ b/discoenv/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.69"
 axum = { version = "0.6.10", features = ["headers", "http2", "macros", "multipart", "ws"] }
+axum-auth = { version = "0.4", default-features = false, features = ["auth-basic"] }
 axum-tracing-opentelemetry = { version = "0.10.0", features = ["jaeger", "tracing_subscriber_ext", "tracer", "otlp"] }
 clap = { version = "4.1.8", features = ["derive", "env"] }
 debuff = { git = "https://github.com/cyverse-de/p", rev="3fefb209bb05bfea5056f8ce42b550287afa1e5b" }

--- a/discoenv/Cargo.toml
+++ b/discoenv/Cargo.toml
@@ -31,6 +31,8 @@ futures = "0.3.28"
 prost = "0.11.8"
 reqwest = { version = "0.11.16", features = ["json", "blocking", "rustls", "tokio-rustls", "rustls-tls"] }
 url = { version = "2.3.1", features = ["serde"] }
+cached = { version = "0.43.0", features = ["serde", "serde_json"] }
+chrono = { version = "0.4.24", features = ["serde"] }
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/discoenv/Cargo.toml
+++ b/discoenv/Cargo.toml
@@ -28,6 +28,7 @@ utoipa-swagger-ui = { version = "3.1.0", features = ["axum", "debug", "debug-emb
 async-nats = { version = "0.29.0", features = ["service"] }
 futures = "0.3.28"
 prost = "0.11.8"
+reqwest = { version = "0.11.16", features = ["json", "blocking", "rustls", "tokio-rustls", "rustls-tls"] }
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/discoenv/src/app_state.rs
+++ b/discoenv/src/app_state.rs
@@ -1,0 +1,30 @@
+use crate::auth;
+use crate::handlers;
+use axum::extract::FromRef;
+use sqlx::{Pool, Postgres};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct DiscoenvState {
+    pub pool: Arc<Pool<Postgres>>,
+    pub handler_config: handlers::config::HandlerConfiguration,
+    pub auth: Option<auth::Authenticator>,
+}
+
+impl FromRef<DiscoenvState> for Arc<Pool<Postgres>> {
+    fn from_ref(state: &DiscoenvState) -> Arc<Pool<Postgres>> {
+        state.pool.clone()
+    }
+}
+
+impl FromRef<DiscoenvState> for handlers::config::HandlerConfiguration {
+    fn from_ref(state: &DiscoenvState) -> handlers::config::HandlerConfiguration {
+        state.handler_config.clone()
+    }
+}
+
+impl FromRef<DiscoenvState> for Option<auth::Authenticator> {
+    fn from_ref(state: &DiscoenvState) -> Option<auth::Authenticator> {
+        state.auth.clone()
+    }
+}

--- a/discoenv/src/app_state.rs
+++ b/discoenv/src/app_state.rs
@@ -1,37 +1,11 @@
 use crate::auth;
 use crate::handlers;
-use axum::extract::FromRef;
 use sqlx::{Pool, Postgres};
-use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct DiscoenvState {
-    pub pool: Arc<Pool<Postgres>>,
+    pub pool: Pool<Postgres>,
     pub handler_config: handlers::config::HandlerConfiguration,
-    pub auth: Option<auth::Authenticator>,
-    pub admin_entitlements: Option<Arc<Vec<String>>>,
-}
-
-impl FromRef<DiscoenvState> for Arc<Pool<Postgres>> {
-    fn from_ref(state: &DiscoenvState) -> Arc<Pool<Postgres>> {
-        state.pool.clone()
-    }
-}
-
-impl FromRef<DiscoenvState> for handlers::config::HandlerConfiguration {
-    fn from_ref(state: &DiscoenvState) -> handlers::config::HandlerConfiguration {
-        state.handler_config.clone()
-    }
-}
-
-impl FromRef<DiscoenvState> for Option<auth::Authenticator> {
-    fn from_ref(state: &DiscoenvState) -> Option<auth::Authenticator> {
-        state.auth.clone()
-    }
-}
-
-impl FromRef<DiscoenvState> for Option<Arc<Vec<String>>> {
-    fn from_ref(state: &DiscoenvState) -> Option<Arc<Vec<String>>> {
-        state.admin_entitlements.clone()
-    }
+    pub auth: auth::Authenticator,
+    pub admin_entitlements: Vec<String>,
 }

--- a/discoenv/src/app_state.rs
+++ b/discoenv/src/app_state.rs
@@ -9,6 +9,7 @@ pub struct DiscoenvState {
     pub pool: Arc<Pool<Postgres>>,
     pub handler_config: handlers::config::HandlerConfiguration,
     pub auth: Option<auth::Authenticator>,
+    pub admin_entitlements: Option<Arc<Vec<String>>>,
 }
 
 impl FromRef<DiscoenvState> for Arc<Pool<Postgres>> {
@@ -26,5 +27,11 @@ impl FromRef<DiscoenvState> for handlers::config::HandlerConfiguration {
 impl FromRef<DiscoenvState> for Option<auth::Authenticator> {
     fn from_ref(state: &DiscoenvState) -> Option<auth::Authenticator> {
         state.auth.clone()
+    }
+}
+
+impl FromRef<DiscoenvState> for Option<Arc<Vec<String>>> {
+    fn from_ref(state: &DiscoenvState) -> Option<Arc<Vec<String>>> {
+        state.admin_entitlements.clone()
     }
 }

--- a/discoenv/src/auth.rs
+++ b/discoenv/src/auth.rs
@@ -94,6 +94,12 @@ pub struct UserInfo {
 }
 impl CanExpire for UserInfo {
     fn is_expired(&self) -> bool {
+        // Don't cache inactive token introspection results.
+        // Could result in users being unable to authenticate for a day after a failure.
+        if !self.active {
+            return true;
+        }
+
         // If both fields are None, then the response is uncacheable.
         if self.iat.is_none() && self.exp.is_none() {
             return true;

--- a/discoenv/src/auth.rs
+++ b/discoenv/src/auth.rs
@@ -1,0 +1,168 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Token {
+    jwt_claims: JWTClaims,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct JWTClaims {
+    uid_domain: String,
+    preferred_username: String,
+    email: String,
+    given_name: String,
+    family_name: String,
+    name: String,
+    entitlement: Vec<String>,
+    realm_access: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct User {
+    uid_domain: String,
+    short_username: String,
+    username: String,
+    email: String,
+    first_name: String,
+    last_name: String,
+    common_name: String,
+    entitlement: Vec<String>,
+}
+
+impl User {
+    pub fn is_service_account(&self) -> bool {
+        is_service_account(&self.short_username)
+    }
+}
+
+impl From<JWTClaims> for User {
+    fn from(claim: JWTClaims) -> Self {
+        let username = format!("{}@{d}", claim.preferred_username, d = claim.uid_domain);
+        User {
+            uid_domain: claim.uid_domain,
+            short_username: claim.preferred_username,
+            username,
+            email: claim.email,
+            first_name: claim.given_name,
+            last_name: claim.family_name,
+            common_name: claim.name,
+            entitlement: claim.entitlement,
+        }
+    }
+}
+
+impl JWTClaims {
+    pub fn is_service_account(&self) -> bool {
+        is_service_account(&self.preferred_username)
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct OIDCKey {
+    kid: String,
+    kty: String,
+    alg: String,
+
+    #[serde(rename = "use")]
+    why: String,
+
+    n: String,
+    e: String,
+    x5c: Vec<String>,
+    x5t: String,
+
+    #[serde(rename = "x5t#S256")]
+    x5t_s256: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct OIDCCert {
+    keys: Vec<OIDCKey>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct OIDCToken {
+    access_token: String,
+    token_type: String,
+    not_before_policy: u64,
+    session_state: String,
+    scope: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct OIDCTokenRequest {
+    grant_type: String,
+    client_id: String,
+    client_secret: String,
+    username: String,
+    password: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct OIDCImpersonationTokenRequest {
+    grant_type: String,
+    client_id: String,
+    client_secret: String,
+    subject_token: String,
+    requested_token_type: String,
+    requested_subject: String,
+}
+
+impl OIDCImpersonationTokenRequest {
+    fn new(client_id: &str, client_secret: &str, subject_token: &str, subject: &str) -> Self {
+        OIDCImpersonationTokenRequest {
+            grant_type: "urn:ietf:params:oauth:grant-type:token-exchange".into(),
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            subject_token: subject_token.into(),
+            requested_token_type: "urn:ietf:params:oauth:token-type:access_token".into(),
+            requested_subject: subject.into(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct TokenIntrospectionRequest {
+    token: String,
+    client_id: String,
+    client_secret: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct TokenIntrospectionResult {
+    active: bool,
+    exp: Option<u64>,
+    iat: Option<u64>,
+    jti: Option<u64>,
+    iss: Option<u64>,
+    sub: Option<String>,
+    typ: Option<String>,
+    azp: Option<String>,
+    session_state: Option<String>,
+    preferred_username: Option<String>,
+    email_verified: Option<bool>,
+    acr: Option<String>,
+    scope: Option<String>,
+
+    #[serde(rename = "DOB")]
+    dob: Option<String>,
+    organization: Option<String>,
+    client_id: Option<String>,
+    client_subject: Option<String>,
+    username: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ServiceAccountInfo {
+    username: String,
+    roles: Vec<String>,
+}
+
+fn is_service_account(username: &str) -> bool {
+    username.starts_with("service-account-")
+}
+
+pub fn token_is_valid(unparsed_token: &str) -> Result<bool, anyhow::Error> {
+    //
+    Ok(true)
+}

--- a/discoenv/src/auth/middleware.rs
+++ b/discoenv/src/auth/middleware.rs
@@ -1,0 +1,48 @@
+use axum::{
+    extract::State,
+    headers::{authorization::Bearer, Authorization},
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::Response,
+    RequestPartsExt, TypedHeader,
+};
+
+use super::{Authenticator, UserInfo};
+
+pub async fn auth_middleware<B>(
+    State(authz_opt): State<Option<Authenticator>>,
+    request: Request<B>,
+    next: Next<B>,
+) -> Result<Response, StatusCode>
+where
+    B: Send,
+{
+    let (mut parts, body) = request.into_parts();
+
+    let mut req: Request<B>;
+    let user_info: UserInfo;
+
+    if let Some(authz) = authz_opt {
+        let bearer: TypedHeader<Authorization<Bearer>> = parts
+            .extract()
+            .await
+            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+        if bearer.token().is_empty() {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+
+        user_info = authz.validate_token(bearer.token()).await?;
+
+        if !user_info.active {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    } else {
+        user_info = UserInfo::default();
+    }
+
+    req = Request::from_parts(parts, body);
+    req.extensions_mut().insert(user_info);
+
+    Ok(next.run(req).await)
+}

--- a/discoenv/src/auth/middleware.rs
+++ b/discoenv/src/auth/middleware.rs
@@ -7,40 +7,36 @@ use axum::{
     response::Response,
     RequestPartsExt, TypedHeader,
 };
+use std::sync::Arc;
 
 use super::UserInfo;
 
 pub async fn auth_middleware<B>(
-    State(state): State<DiscoenvState>,
+    State(state): State<Arc<DiscoenvState>>,
     request: Request<B>,
     next: Next<B>,
 ) -> Result<Response, StatusCode>
 where
     B: Send,
 {
+    let authz = &state.auth;
     let (mut parts, body) = request.into_parts();
 
     let mut req: Request<B>;
-    let user_info: UserInfo;
 
-    if let Some(authz) = state.auth {
-        // Make sure the token is present and valid
-        let bearer: TypedHeader<Authorization<Bearer>> = parts
-            .extract()
-            .await
-            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    let bearer: TypedHeader<Authorization<Bearer>> = parts
+        .extract()
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-        if bearer.token().is_empty() {
-            return Err(StatusCode::UNAUTHORIZED);
-        }
+    if bearer.token().is_empty() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
 
-        user_info = authz.validate_token(bearer.token()).await?;
+    let user_info = authz.validate_token(bearer.token()).await?;
 
-        if !user_info.active {
-            return Err(StatusCode::UNAUTHORIZED);
-        }
-    } else {
-        user_info = UserInfo::default();
+    if !user_info.active {
+        return Err(StatusCode::UNAUTHORIZED);
     }
 
     req = Request::from_parts(parts, body);
@@ -50,51 +46,50 @@ where
 }
 
 pub async fn require_entitlements<B>(
-    State(state): State<DiscoenvState>,
+    State(state): State<Arc<DiscoenvState>>,
     request: Request<B>,
     next: Next<B>,
 ) -> Result<Response, StatusCode>
 where
     B: Send,
 {
+    let check_ents = &state.admin_entitlements;
     let (mut parts, body) = request.into_parts();
 
-    if let Some(check_ents) = state.admin_entitlements {
-        // This check requires that the user info be passed in,
-        // so if it's not there, they're unauthed.
-        let user_info: Extension<UserInfo> = parts
-            .extract()
-            .await
-            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    // This check requires that the user info be passed in,
+    // so if it's not there, they're unauthed.
+    let user_info: Extension<UserInfo> = parts
+        .extract()
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-        // If they have no entitlements in the user info,
-        // they're not supposed to access this call.
-        if user_info.entitlement.is_none() {
-            return Err(StatusCode::FORBIDDEN);
-        }
-        let user_ents = user_info.entitlement.to_owned().unwrap_or(vec![]);
-        let mut found_ent = false;
+    // If they have no entitlements in the user info,
+    // they're not supposed to access this call.
+    if user_info.entitlement.is_none() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    let user_ents = user_info.entitlement.to_owned().unwrap_or(vec![]);
+    let mut found_ent = false;
 
-        // See if any of the user's entitlments are in the
-        // list of admin entitlments listed in the configuration.
-        for req_ent in check_ents.iter() {
-            for user_ent in user_ents.iter() {
-                if user_ent == req_ent {
-                    println!("found entitlement: {}", user_ent);
-                    found_ent = true
-                }
-            }
-
-            if found_ent {
-                break;
+    // See if any of the user's entitlments are in the
+    // list of admin entitlments listed in the configuration.
+    for req_ent in check_ents.iter() {
+        for user_ent in user_ents.iter() {
+            if user_ent == req_ent {
+                println!("found entitlement: {}", user_ent);
+                found_ent = true
             }
         }
 
-        // If none of the user's entitlements are admin entitlements,
-        // then they're not allowed to make the call.
-        if !found_ent {
-            return Err(StatusCode::FORBIDDEN);
+        if found_ent {
+            break;
         }
+    }
+
+    // If none of the user's entitlements are admin entitlements,
+    // then they're not allowed to make the call.
+    if !found_ent {
+        return Err(StatusCode::FORBIDDEN);
     }
 
     // If the user didn't configure any admin entitlements, then let the call through.

--- a/discoenv/src/auth/middleware.rs
+++ b/discoenv/src/auth/middleware.rs
@@ -72,13 +72,13 @@ where
         if user_info.entitlement.is_none() {
             return Err(StatusCode::FORBIDDEN);
         }
-
+        let user_ents = user_info.entitlement.to_owned().unwrap_or(vec![]);
         let mut found_ent = false;
 
         // See if any of the user's entitlments are in the
         // list of admin entitlments listed in the configuration.
         for req_ent in check_ents.iter() {
-            for user_ent in user_info.entitlement.clone().unwrap_or(vec![]).iter() {
+            for user_ent in user_ents.iter() {
                 if user_ent == req_ent {
                     println!("found entitlement: {}", user_ent);
                     found_ent = true

--- a/discoenv/src/auth/mod.rs
+++ b/discoenv/src/auth/mod.rs
@@ -4,10 +4,11 @@ use cached::{proc_macro::cached, stores::CanExpire};
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::{ParseError, Url};
+use utoipa::ToSchema;
 
 use crate::errors::DiscoError;
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, ToSchema, Serialize, Deserialize)]
 pub struct Token {
     access_token: String,
     token_type: String,

--- a/discoenv/src/auth/mod.rs
+++ b/discoenv/src/auth/mod.rs
@@ -1,3 +1,5 @@
+pub mod middleware;
+
 use cached::{proc_macro::cached, stores::CanExpire};
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/discoenv/src/auth/mod.rs
+++ b/discoenv/src/auth/mod.rs
@@ -135,7 +135,7 @@ impl CanExpire for UserInfo {
 
         // If the call gets here, then the token isn't older than a day and hasn't expired.
         // It can be cached.
-        return false;
+        false
     }
 }
 

--- a/discoenv/src/handlers/analyses.rs
+++ b/discoenv/src/handlers/analyses.rs
@@ -34,10 +34,11 @@ use super::config;
     tag = "analyses"
 )]
 pub async fn get_user_analyses(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(pool): State<Arc<PgPool>>,
+    State(handler_config): State<config::HandlerConfiguration>,
     Path(username): Path<String>,
 ) -> response::Result<Json<Vec<analysis::Analysis>>, DiscoError> {
-    let mut tx = conn.begin().await?;
-    let user = common::validate_username(&mut tx, &username, &cfg).await?;
+    let mut tx = pool.begin().await?;
+    let user = common::validate_username(&mut tx, &username, &handler_config).await?;
     Ok(Json(analyses::get_user_analyses(&mut tx, &user).await?))
 }

--- a/discoenv/src/handlers/analyses.rs
+++ b/discoenv/src/handlers/analyses.rs
@@ -18,6 +18,9 @@ use super::common;
     params(
         ("username" = String, Path, description = "A username"),
     ),
+    security(
+      ("api_key" = []),  
+    ),
     responses(
         (status = 200, description = "Lists all of a user's analyses", body = Bags),
         (status = 400, description = "Bad request.", 

--- a/discoenv/src/handlers/bags.rs
+++ b/discoenv/src/handlers/bags.rs
@@ -4,20 +4,15 @@ use axum::{
     response,
 };
 use serde_json::Map;
-use sqlx::{
-    postgres::PgPool,
-    types::{JsonValue, Uuid},
-};
+use sqlx::types::{JsonValue, Uuid};
 use std::sync::Arc;
 
 
 use crate::db::{bags::{self, Bag}, users};
 use crate::db::bags::{list_user_bags, Bags};
 use crate::errors::DiscoError;
-
-use super::config;
+use crate::app_state::DiscoenvState;
 use super::common;
-
 
 /// Get all of a user's bags.
 /// 
@@ -43,11 +38,12 @@ use super::common;
     tag = "bag"
 )]
 pub async fn get_user_bags(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,   // Extracts the pool from the state.
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>, // Pulls the username out out of the Path and turns it into a String.
 ) -> response::Result<Json<Bags>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -81,11 +77,12 @@ pub async fn get_user_bags(
     tag = "bag"
 )]
 pub async fn delete_user_bags(
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,   // Extracts the pool from the state.
 ) -> response::Result<(), DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -124,12 +121,13 @@ pub async fn delete_user_bags(
     tag = "bag"
 )]
 pub  async fn add_user_bag(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
     Json(bag): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<common::ID>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -167,13 +165,14 @@ pub  async fn add_user_bag(
     tag = "bag"
 )]
 pub async fn user_has_bags(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
 ) -> response::Result<StatusCode, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut status_code = StatusCode::OK;
-    let has_bag = bags::user_has_bags(conn.as_ref(), &user).await?;
+    let has_bag = bags::user_has_bags(conn, &user).await?;
     if !has_bag {
         status_code = StatusCode::NOT_FOUND
     }
@@ -202,11 +201,12 @@ pub async fn user_has_bags(
     tag = "bag"
 )]
 pub async fn get_bag(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path((username, bag_id)): Path<(String, Uuid)>,
 ) -> response::Result<Json<Bag>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -241,12 +241,13 @@ pub async fn get_bag(
     tag = "bag"
 )]
 pub async fn update_bag(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path((username, bag_id)): Path<(String, Uuid)>,
     Json(bag): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Bag>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -286,11 +287,12 @@ pub async fn update_bag(
     tag = "bag"
 )]
 pub async fn delete_bag(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path((username, bag_id)): Path<(String, Uuid)>,
 ) -> response::Result<(), DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -325,11 +327,12 @@ pub async fn delete_bag(
     tag = "bag"
 )]
 pub async fn get_default_bag(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
 ) -> response::Result<Json<Bag>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -338,7 +341,7 @@ pub async fn get_default_bag(
 
     if !bags::has_default_bag(&mut tx, &user).await? {
         let new_bag: Map<String, JsonValue> = Map::new();
-        let new_bag_uuid = bags::add_user_bag(conn.as_ref(), &user, new_bag).await?;
+        let new_bag_uuid = bags::add_user_bag(conn, &user, new_bag).await?;
         bags::set_default_bag(&mut tx, &user, &new_bag_uuid).await?;
     }
 
@@ -369,12 +372,13 @@ pub async fn get_default_bag(
     tag = "bag"
 )]
 pub async fn update_default_bag(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
     Json(bag): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Bag>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -414,11 +418,12 @@ pub async fn update_default_bag(
     tag = "bag"
 )]
 pub async fn delete_default_bag(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
 ) -> response::Result<(), DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {

--- a/discoenv/src/handlers/bags.rs
+++ b/discoenv/src/handlers/bags.rs
@@ -43,7 +43,8 @@ use super::common;
     tag = "bag"
 )]
 pub async fn get_user_bags(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,   // Extracts the pool from the state.
     Path(username): Path<String>, // Pulls the username out out of the Path and turns it into a String.
 ) -> response::Result<Json<Bags>, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -80,8 +81,9 @@ pub async fn get_user_bags(
     tag = "bag"
 )]
 pub async fn delete_user_bags(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
     Path(username): Path<String>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,   // Extracts the pool from the state.
 ) -> response::Result<(), DiscoError> {
     let user = common::fix_username(&username, &cfg);
     let mut tx = conn.begin().await?;
@@ -122,7 +124,8 @@ pub async fn delete_user_bags(
     tag = "bag"
 )]
 pub  async fn add_user_bag(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
     Json(bag): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<common::ID>, DiscoError> {
@@ -164,7 +167,8 @@ pub  async fn add_user_bag(
     tag = "bag"
 )]
 pub async fn user_has_bags(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> response::Result<StatusCode, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -198,7 +202,8 @@ pub async fn user_has_bags(
     tag = "bag"
 )]
 pub async fn get_bag(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path((username, bag_id)): Path<(String, Uuid)>,
 ) -> response::Result<Json<Bag>, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -236,7 +241,8 @@ pub async fn get_bag(
     tag = "bag"
 )]
 pub async fn update_bag(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path((username, bag_id)): Path<(String, Uuid)>,
     Json(bag): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Bag>, DiscoError> {
@@ -280,7 +286,8 @@ pub async fn update_bag(
     tag = "bag"
 )]
 pub async fn delete_bag(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path((username, bag_id)): Path<(String, Uuid)>,
 ) -> response::Result<(), DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -318,7 +325,8 @@ pub async fn delete_bag(
     tag = "bag"
 )]
 pub async fn get_default_bag(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> response::Result<Json<Bag>, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -361,7 +369,8 @@ pub async fn get_default_bag(
     tag = "bag"
 )]
 pub async fn update_default_bag(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
     Json(bag): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Bag>, DiscoError> {
@@ -405,7 +414,8 @@ pub async fn update_default_bag(
     tag = "bag"
 )]
 pub async fn delete_default_bag(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,   // Extracts the pool from the state.
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> response::Result<(), DiscoError> {
     let user = common::fix_username(&username, &cfg);

--- a/discoenv/src/handlers/config.rs
+++ b/discoenv/src/handlers/config.rs
@@ -2,4 +2,5 @@
 pub struct HandlerConfiguration {
     pub append_user_domain: bool,
     pub user_domain: String,
+    pub do_auth: bool,
 }

--- a/discoenv/src/handlers/preferences.rs
+++ b/discoenv/src/handlers/preferences.rs
@@ -36,7 +36,8 @@ use super::config;
     tag = "preferences"
 )]
 pub async fn get_user_preferences(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> response::Result<Json<Preferences>, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -75,7 +76,8 @@ pub async fn get_user_preferences(
 
 )]
 pub async fn add_user_preferences(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
     Json(preferences): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<common::ID>, DiscoError> {
@@ -123,7 +125,8 @@ pub async fn add_user_preferences(
     tag = "preferences"
 )]
 pub async fn update_user_preferences(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
     Json(preferences): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Preferences>, DiscoError> {
@@ -171,7 +174,8 @@ pub async fn update_user_preferences(
 
 )]
 pub async fn delete_user_preferences(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> response::Result<(), DiscoError> {
     let user = common::fix_username(&username, &cfg);

--- a/discoenv/src/handlers/preferences.rs
+++ b/discoenv/src/handlers/preferences.rs
@@ -3,15 +3,14 @@ use axum::{
     response,
 };
 use serde_json::Map;
-use sqlx::{postgres::PgPool, types::JsonValue};
+use sqlx::types::JsonValue;
 use std::sync::Arc;
 
-use crate::db::preferences::{self, Preferences};
+use crate::{db::preferences::{self, Preferences}, app_state::DiscoenvState};
 use crate::db::users;
 use crate::errors::DiscoError;
 
 use super::common;
-use super::config;
 
 /// Get the user's preferences.
 ///
@@ -36,11 +35,12 @@ use super::config;
     tag = "preferences"
 )]
 pub async fn get_user_preferences(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
 ) -> response::Result<Json<Preferences>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
     if !users::username_exists(&mut tx, &user).await? {
         return Err(DiscoError::NotFound(format!("user {} was not found", user)));
@@ -76,12 +76,13 @@ pub async fn get_user_preferences(
 
 )]
 pub async fn add_user_preferences(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
     Json(preferences): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<common::ID>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -125,11 +126,12 @@ pub async fn add_user_preferences(
     tag = "preferences"
 )]
 pub async fn update_user_preferences(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
     Json(preferences): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Preferences>, DiscoError> {
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
     let user = common::fix_username(&username, &cfg);
     let mut tx = conn.begin().await?;
 
@@ -174,11 +176,12 @@ pub async fn update_user_preferences(
 
 )]
 pub async fn delete_user_preferences(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,    
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
 ) -> response::Result<(), DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {

--- a/discoenv/src/handlers/searches.rs
+++ b/discoenv/src/handlers/searches.rs
@@ -38,7 +38,8 @@ use super::config;
     tag = "searches"
 )]
 pub async fn get_saved_searches(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> response::Result<Json<SavedSearches>, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -74,7 +75,8 @@ pub async fn get_saved_searches(
     tag = "searches"
 )]
 pub async fn has_saved_searches(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> response::Result<StatusCode, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -111,7 +113,8 @@ pub async fn has_saved_searches(
     tag = "searches"
 )]
 pub async fn add_saved_searches(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
     Json(saved_searches): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<common::ID>, DiscoError> {
@@ -152,7 +155,8 @@ pub async fn add_saved_searches(
     tag = "searches"
 )]
 pub async fn update_saved_searches(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
     Json(saved_searches): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<SavedSearches>, DiscoError> {
@@ -193,7 +197,8 @@ pub async fn update_saved_searches(
     tag = "searches"
 )]
 pub async fn delete_saved_searches(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,    
     Path(username): Path<String>,
 ) -> Result<(), DiscoError> {
     let user = common::fix_username(&username, &cfg);

--- a/discoenv/src/handlers/sessions.rs
+++ b/discoenv/src/handlers/sessions.rs
@@ -3,22 +3,23 @@ use axum::{
     response,
 };
 use serde_json::Map;
-use sqlx::{postgres::PgPool, types::JsonValue};
+use sqlx::types::JsonValue;
 use std::sync::Arc;
 
+use crate::app_state::DiscoenvState;
 use crate::db::sessions::{self, Session};
 use crate::db::users;
 use crate::errors::DiscoError;
 
 use super::common;
-use super::config;
 
 pub async fn get_user_sessions(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
 ) -> response::Result<Json<Session>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -29,12 +30,13 @@ pub async fn get_user_sessions(
 }
 
 pub async fn add_user_sessions(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
     Json(sessions): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<common::ID>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -54,12 +56,13 @@ pub async fn add_user_sessions(
 }
 
 pub async fn update_user_sessions(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
     Json(sessions): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Session>, DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {
@@ -79,11 +82,12 @@ pub async fn update_user_sessions(
 }
 
 pub async fn delete_user_sessions(
-    State(conn): State<Arc<PgPool>>,
-    State(cfg): State<config::HandlerConfiguration>,
+    State(state): State<Arc<DiscoenvState>>,
     Path(username): Path<String>,
 ) -> response::Result<(), DiscoError> {
-    let user = common::fix_username(&username, &cfg);
+    let conn = &state.pool;
+    let cfg = &state.handler_config;
+    let user = common::fix_username(&username, cfg);
     let mut tx = conn.begin().await?;
 
     if !users::username_exists(&mut tx, &user).await? {

--- a/discoenv/src/handlers/sessions.rs
+++ b/discoenv/src/handlers/sessions.rs
@@ -14,7 +14,8 @@ use super::common;
 use super::config;
 
 pub async fn get_user_sessions(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,
     Path(username): Path<String>,
 ) -> response::Result<Json<Session>, DiscoError> {
     let user = common::fix_username(&username, &cfg);
@@ -28,7 +29,8 @@ pub async fn get_user_sessions(
 }
 
 pub async fn add_user_sessions(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,
     Path(username): Path<String>,
     Json(sessions): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<common::ID>, DiscoError> {
@@ -52,7 +54,8 @@ pub async fn add_user_sessions(
 }
 
 pub async fn update_user_sessions(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,
     Path(username): Path<String>,
     Json(sessions): Json<Map<String, JsonValue>>,
 ) -> response::Result<Json<Session>, DiscoError> {
@@ -76,7 +79,8 @@ pub async fn update_user_sessions(
 }
 
 pub async fn delete_user_sessions(
-    State((conn, cfg)): State<(Arc<PgPool>, config::HandlerConfiguration)>,
+    State(conn): State<Arc<PgPool>>,
+    State(cfg): State<config::HandlerConfiguration>,
     Path(username): Path<String>,
 ) -> response::Result<(), DiscoError> {
     let user = common::fix_username(&username, &cfg);

--- a/discoenv/src/handlers/tokens.rs
+++ b/discoenv/src/handlers/tokens.rs
@@ -5,13 +5,40 @@ use axum::{
 use axum_auth::AuthBasic;
 use std::sync::Arc;
 
-use crate::{app_state::DiscoenvState, auth, errors::DiscoError};
+use crate::{
+    app_state::DiscoenvState,
+    auth::{self, Token},
+    errors::DiscoError,
+};
 
+#[utoipa::path(
+    get,
+    path = "/token",
+    security(
+        ("http" = []) // Use HTTP basic auth here.
+    ),
+    responses(
+        (status = 200, description = "Tokens generated for authentication", body = Token),
+        (status = 401, description = "Unauthorized", body = DiscoError,
+            example = json!(DiscoError::Unauthenticated("unauthorized".to_owned()).create_service_error())),
+        (status = 400, description = "Bad request.", 
+            body = DiscoError,
+            example = json!(DiscoError::BadRequest("bad request".to_owned()).create_service_error())),
+        (status = 404, description = "User didn't exist.", 
+            body = DiscoError,
+            example = json!(DiscoError::NotFound("user wasn't found".to_owned()).create_service_error())),
+        (status = 500, description = "Internal error.", 
+            body = DiscoError,
+            example = json!(DiscoError::Internal("internal error".to_owned()).create_service_error())),
+    ),
+    tag = "auth"
+)]
 pub async fn get_token(
     State(state): State<Arc<DiscoenvState>>,
     AuthBasic((username, password)): AuthBasic,
 ) -> response::Result<Json<auth::Token>, DiscoError> {
     let a = &state.auth;
     let password = password.unwrap_or_default();
-    Ok(Json(a.get_token(&username, &password).await?))
+    let t: Token = a.get_token(&username, &password).await?;
+    Ok(Json(t))
 }

--- a/discoenv/src/handlers/tokens.rs
+++ b/discoenv/src/handlers/tokens.rs
@@ -12,16 +12,14 @@ use crate::{
 pub async fn get_token(
     AuthBasic((username, password)): AuthBasic,
     State(authz_opt): State<Option<Authenticator>>,
-) -> response::Result<Json<auth::OIDCToken>, DiscoError> {
+) -> response::Result<Json<auth::Token>, DiscoError> {
     let password = password.unwrap_or_default();
     println!("{:?}", username);
     println!("{:?}", password);
     println!("{:?}", authz_opt);
 
     if let Some(a) = authz_opt {
-        let r = a.get_token(&username, &password).await?;
-        println!("{:?}", r);
-        Ok(Json(r))
+        Ok(Json(a.get_token(&username, &password).await?))
     } else {
         Err(DiscoError::BadRequest("authentication not enabled".into()))
     }

--- a/discoenv/src/handlers/tokens.rs
+++ b/discoenv/src/handlers/tokens.rs
@@ -1,0 +1,27 @@
+use axum::{
+    extract::{Json, State},
+    response,
+};
+use axum_auth::AuthBasic;
+
+use crate::{
+    auth::{self, Authenticator},
+    errors::DiscoError,
+};
+
+pub async fn get_token(
+    AuthBasic((username, password)): AuthBasic,
+    State(authz_opt): State<Option<Authenticator>>,
+) -> response::Result<Json<auth::OIDCToken>, DiscoError> {
+    let password = password.unwrap_or_default();
+
+    if let Some(auth) = authz_opt {
+        Ok(Json(
+            auth.get_token(&username, &password)
+                .await
+                .map_err(|re| DiscoError::BadRequest(re.to_string()))?,
+        ))
+    } else {
+        Err(DiscoError::BadRequest("authentication not enabled".into()))
+    }
+}

--- a/discoenv/src/handlers/tokens.rs
+++ b/discoenv/src/handlers/tokens.rs
@@ -14,10 +14,6 @@ pub async fn get_token(
     State(authz_opt): State<Option<Authenticator>>,
 ) -> response::Result<Json<auth::Token>, DiscoError> {
     let password = password.unwrap_or_default();
-    println!("{:?}", username);
-    println!("{:?}", password);
-    println!("{:?}", authz_opt);
-
     if let Some(a) = authz_opt {
         Ok(Json(a.get_token(&username, &password).await?))
     } else {

--- a/discoenv/src/handlers/tokens.rs
+++ b/discoenv/src/handlers/tokens.rs
@@ -3,20 +3,15 @@ use axum::{
     response,
 };
 use axum_auth::AuthBasic;
+use std::sync::Arc;
 
-use crate::{
-    auth::{self, Authenticator},
-    errors::DiscoError,
-};
+use crate::{app_state::DiscoenvState, auth, errors::DiscoError};
 
 pub async fn get_token(
+    State(state): State<Arc<DiscoenvState>>,
     AuthBasic((username, password)): AuthBasic,
-    State(authz_opt): State<Option<Authenticator>>,
 ) -> response::Result<Json<auth::Token>, DiscoError> {
+    let a = &state.auth;
     let password = password.unwrap_or_default();
-    if let Some(a) = authz_opt {
-        Ok(Json(a.get_token(&username, &password).await?))
-    } else {
-        Err(DiscoError::BadRequest("authentication not enabled".into()))
-    }
+    Ok(Json(a.get_token(&username, &password).await?))
 }

--- a/discoenv/src/handlers/tokens.rs
+++ b/discoenv/src/handlers/tokens.rs
@@ -14,13 +14,14 @@ pub async fn get_token(
     State(authz_opt): State<Option<Authenticator>>,
 ) -> response::Result<Json<auth::OIDCToken>, DiscoError> {
     let password = password.unwrap_or_default();
+    println!("{:?}", username);
+    println!("{:?}", password);
+    println!("{:?}", authz_opt);
 
-    if let Some(auth) = authz_opt {
-        Ok(Json(
-            auth.get_token(&username, &password)
-                .await
-                .map_err(|re| DiscoError::BadRequest(re.to_string()))?,
-        ))
+    if let Some(a) = authz_opt {
+        let r = a.get_token(&username, &password).await?;
+        println!("{:?}", r);
+        Ok(Json(r))
     } else {
         Err(DiscoError::BadRequest("authentication not enabled".into()))
     }

--- a/discoenv/src/lib.rs
+++ b/discoenv/src/lib.rs
@@ -18,5 +18,6 @@ pub mod db {
     pub mod users;
 }
 
+pub mod auth;
 pub mod errors;
 pub mod signals;

--- a/discoenv/src/lib.rs
+++ b/discoenv/src/lib.rs
@@ -18,6 +18,7 @@ pub mod db {
     pub mod users;
 }
 
+pub mod app_state;
 pub mod auth;
 pub mod errors;
 pub mod signals;

--- a/discoenv/src/lib.rs
+++ b/discoenv/src/lib.rs
@@ -7,6 +7,7 @@ pub mod handlers {
     pub mod preferences;
     pub mod searches;
     pub mod sessions;
+    pub mod tokens;
 }
 
 pub mod db {

--- a/discoenv/src/main.rs
+++ b/discoenv/src/main.rs
@@ -75,7 +75,7 @@ where
     let (mut parts, body) = request.into_parts();
 
     let mut req: Request<B>;
-    let mut user_info: auth::UserInfo;
+    let user_info: auth::UserInfo;
     
     if let Some(authz) = authz_opt {
         let bearer: TypedHeader<Authorization<Bearer>> = parts

--- a/discoenv/src/main.rs
+++ b/discoenv/src/main.rs
@@ -253,6 +253,7 @@ async fn main() -> Result<()> {
         .nest("/sessions", sessions_routes)
         .nest("/preferences", pref_routes)
         .route("/otel", get(handlers::otel::report_otel))
+        .route("/token", get(handlers::tokens::get_token))
         .layer(response_with_trace_layer())
         .layer(opentelemetry_tracing_layer())
         .with_state(state);

--- a/discoenv/src/main.rs
+++ b/discoenv/src/main.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use axum_tracing_opentelemetry::{opentelemetry_tracing_layer, response_with_trace_layer};
 use clap::Parser;
+use discoenv::auth::middleware::RequireEntitlementsLayer;
 use discoenv::db::{bags, preferences, searches};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
@@ -203,7 +204,8 @@ async fn main() -> Result<()> {
             "/:username",
             get(handlers::analyses::get_user_analyses)
         )
-        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
+        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
+        .layer(RequireEntitlementsLayer::new(String::from("dev")));
 
     let app = Router::new()
         .route("/", get(|| async {}))

--- a/discoenv/src/main.rs
+++ b/discoenv/src/main.rs
@@ -82,11 +82,10 @@ where
         if bearer.token().is_empty() {
             return Err(StatusCode::UNAUTHORIZED);
         }
-
+       
         let is_okay = authz.validate_token(bearer.token())
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        
+            .await?;
+      
         if !is_okay {
             return Err(StatusCode::UNAUTHORIZED);
         }

--- a/discoenv/src/main.rs
+++ b/discoenv/src/main.rs
@@ -220,8 +220,6 @@ async fn main() -> Result<()> {
         .route(
             "/:username",
             get(handlers::analyses::get_user_analyses)
-                .layer(ent_m(service_state.clone()))
-                .layer(auth_m(service_state.clone()))
         )
         .layer(ent_m(service_state.clone()))
         .layer(auth_m(service_state.clone()));


### PR DESCRIPTION
Adds support for authenticating to keycloak and checking user entitlements before allowing a request to an endpoint to be processed. Includes timed caching of the token introspection result along with obeying the expiration date on the token.

Admin entitlements are specified in the configuration file.